### PR TITLE
Updating Portal PH and Ward Tunnel capacities

### DIFF
--- a/pywr-models/models/upper_san_joaquin/pywr_model.json
+++ b/pywr-models/models/upper_san_joaquin/pywr_model.json
@@ -2218,7 +2218,7 @@
             "comment": "{\"resource_class\": \"node\"}",
             "head": 54.864000000000004,
             "turbine_capacity": 1.77132,
-            "flow_capacity": 1.77132,
+            "flow_capacity": 4.30597304814,
             "spinning_flow": 0.15,
             "spinning_cost": -9000,
             "cost": [

--- a/pywr-models/models/upper_san_joaquin/pywr_model.json
+++ b/pywr-models/models/upper_san_joaquin/pywr_model.json
@@ -638,13 +638,13 @@
             "name": "Below Portal Aqueduct Inflow",
             "type": "Link",
             "comment": "{\"resource_class\": \"link\"}",
-            "max_flow": 4.306175990354166
+            "max_flow": 4.30597304814
         },
         {
             "name": "Below Portal Penstock Diverted Inflow",
             "type": "Link",
             "comment": "{\"resource_class\": \"link\"}",
-            "max_flow": 3.6702719917785904
+            "max_flow": 4.30597304814
         },
         {
             "name": "Below Portal Penstock Inflow.1",
@@ -2217,8 +2217,8 @@
             "type": "Hydropower",
             "comment": "{\"resource_class\": \"node\"}",
             "head": 54.864000000000004,
-            "turbine_capacity": 4.23,
-            "flow_capacity": 4.23,
+            "turbine_capacity": 1.77132,
+            "flow_capacity": 1.77132,
             "spinning_flow": 0.15,
             "spinning_cost": -9000,
             "cost": [


### PR DESCRIPTION
Portal Powerhouse

According to this document: https://www1.sce.com/nrc/bigcreek/2000_IIP.pdf, the capacity of Ward Tunnel is 1760 cfs, but the capacity of Portal Powerhouse is 724cfs, as follows:

Discharge from the (Florence Lake) reservoir is "normally controlled to supply water to Huntington Lake. Part of this discharge, up to 724 cfs, passes through Portal Powerhouse before entering Huntington Lake. As such, Florence Lake acts as a storage reservoir for the Portal Powerhouse." 

Appendix C-9

Ward Tunnel surge chamber is a 15 feet diameter, 175 feet high, bore through granite, concrete lined at its upper end, with an overflow crest at elevation 7,180 feet msl. Overflow from the top of the surge chamber runs into a buried 72-inchdiameter reinforced concrete pipe, approximately 556 feet long, which reduces to 48-inch-diameter before connecting to an energy dissipation structure at its downstream end. The energy dissipation structure consists of a compartmented, reinforced concrete box, approximately 25 x 25 x 15 feet high, which discharges into Rancheria Creek near Portal Powerhouse, and then to Huntington Lake. The water conduit from Florence Lake to Huntington Lake is designed to carry approximately 1,760 cfs under optimum conditions.

Appendix C-13