### PR TITLE
render gv schematic only if Graphviz is not installed

### DIFF
--- a/sierra/run_basin_model.py
+++ b/sierra/run_basin_model.py
@@ -11,6 +11,7 @@ import pandas as pd
 import traceback
 from sierra.utilities import simplify_network, prepare_planning_model, save_model_results, create_schematic
 from loguru import logger
+from graphviz import ExecutableNotFound
 
 SECONDS_IN_DAY = 3600 * 24
 
@@ -231,6 +232,8 @@ def _run_model(climate,
                 create_schematic(basin, 'simplified')
             except FileNotFoundError as err:
                 logger.warning('Could not create schematic from Livneh model.')
+            except ExecutableNotFound:
+                logger.warning('Could not create daily schematic from Livneh model.')
 
         model_path = simplified_model_path
 

--- a/sierra/utilities/schematics.py
+++ b/sierra/utilities/schematics.py
@@ -27,9 +27,10 @@ fontcolors = {
 
 # dot = Digraph(comment='System')
 
-def create_schematic(basin, version, format='pdf', view=False):
+def create_schematic(basin, version, format='pdf', render=False, view=False):
     try:
         from graphviz import Digraph, ExecutableNotFound
+        from graphviz.backend import CalledProcessError
     except:
         logger.warning('Graphviz python package not installed.')
         return
@@ -101,12 +102,16 @@ def create_schematic(basin, version, format='pdf', view=False):
                     pass
         _dot.edges([edge])
 
-    outpath1 = os.path.join('./schematics', '{}_schematic{}.gv'.format(basin, '' if not version else '_' + version))
-    _dot.render(outpath1, view=view)
-    # if format == 'png':
-    # outpath2 = os.path.join('./dashapp/assets/schematics',
-    #                         '{}_schematic{}.gv'.format(basin, '' if not version else '_' + version))
-    # _dot.render(outpath2, view=False)
+    schematics_dir = './schematics'
+    gv_filename = '{}_schematic{}.gv'.format(basin, '' if not version else '_' + version)
+    if render:
+        outpath = os.path.join(schematics_dir, gv_filename)
+        try:
+            _dot.render(outpath, view=view)
+        except CalledProcessError as err:
+            logger.warning('Could not create {} schematic. {}'.format(format, err))
+    else:
+        _dot.save(gv_filename, schematics_dir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The title says it all: if Graphviz is not installed, then only text-based Graphviz files will be created for schematics when running in debug mode.