### PR TITLE
refactor: WaterLPParameter -> BaseParameter

### DIFF
--- a/sierra/base_parameters/BaseParameter.py
+++ b/sierra/base_parameters/BaseParameter.py
@@ -12,7 +12,7 @@ class Timestep(object):
     month = None
 
 
-class WaterLPParameter(Parameter):
+class BaseParameter(Parameter):
     cfs_to_cms = 1 / 35.315
 
     mode = 'scheduling'
@@ -79,7 +79,7 @@ class WaterLPParameter(Parameter):
             self.elevation_param = '{}/Elevation'.format(self.res_name) + self.month_suffix
 
     def before(self):
-        super(WaterLPParameter, self).before()
+        super(BaseParameter, self).before()
         self.datetime = self.model.timestepper.current.datetime
 
         if self.model.mode == 'planning':

--- a/sierra/base_parameters/IFRParameter.py
+++ b/sierra/base_parameters/IFRParameter.py
@@ -1,7 +1,7 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class IFRParameter(WaterLPParameter):
+class IFRParameter(BaseParameter):
     ifrs_idx = None
     ifr_names = None
     ifr_type = 'basic'

--- a/sierra/base_parameters/__init__.py
+++ b/sierra/base_parameters/__init__.py
@@ -1,4 +1,4 @@
-from .WaterLPParameter import WaterLPParameter
+from .BaseParameter import BaseParameter
 from .IFRParameter import IFRParameter
 from .FlowRangeParameter import FlowRangeParameter
 from .MinFlowParameter import MinFlowParameter

--- a/sierra/models/merced/_parameters/Exchequer_Dam_Flood_Release_Requirement.py
+++ b/sierra/models/merced/_parameters/Exchequer_Dam_Flood_Release_Requirement.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 from scipy import interpolate
 from sierra.utilities.converter import convert
 
 
-class Exchequer_Dam_Flood_Release_Requirement(WaterLPParameter):
+class Exchequer_Dam_Flood_Release_Requirement(BaseParameter):
     """
     This policy calculates release from Exchequer Dam.
     """

--- a/sierra/models/merced/_parameters/Lake_McClure_Spill_Max_Flow.py
+++ b/sierra/models/merced/_parameters/Lake_McClure_Spill_Max_Flow.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from scipy import interpolate
 
 
-class Lake_McClure_Spill_Max_Flow(WaterLPParameter):
+class Lake_McClure_Spill_Max_Flow(BaseParameter):
     """"""
 
     def _value(self, timestep, scenario_index):

--- a/sierra/models/merced/_parameters/Lake_McClure_Water_Demand.py
+++ b/sierra/models/merced/_parameters/Lake_McClure_Water_Demand.py
@@ -1,7 +1,7 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class Lake_McClure_Water_Demand(WaterLPParameter):
+class Lake_McClure_Water_Demand(BaseParameter):
     """"""
 
     def _value(self, timestep, scenario_index):

--- a/sierra/models/merced/_parameters/MID_Main_Demand.py
+++ b/sierra/models/merced/_parameters/MID_Main_Demand.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class MID_Main_Demand(WaterLPParameter):
+class MID_Main_Demand(BaseParameter):
     """"""
     MID_bias_factor = 1.14
 

--- a/sierra/models/merced/_parameters/MID_Northside_Demand.py
+++ b/sierra/models/merced/_parameters/MID_Northside_Demand.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class MID_Northside_Demand(WaterLPParameter):
+class MID_Northside_Demand(BaseParameter):
     """"""
 
     reductions = [0, 0]

--- a/sierra/models/merced/policies/IFRs_old.py
+++ b/sierra/models/merced/policies/IFRs_old.py
@@ -1,8 +1,8 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 from datetime import date
 
 
-class Requirement_Merced_R_below_Merced_Falls_PH(WaterLPParameter):
+class Requirement_Merced_R_below_Merced_Falls_PH(BaseParameter):
     """
     This policy calculates instream flow requirements in the Merced River below the Merced Falls powerhouse.
     """

--- a/sierra/models/stanislaus/_parameters/Donnells_PH_Turbine_Capacity.py
+++ b/sierra/models/stanislaus/_parameters/Donnells_PH_Turbine_Capacity.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class Donnells_PH_Turbine_Capacity(WaterLPParameter):
+class Donnells_PH_Turbine_Capacity(BaseParameter):
 
     def _value(self, timestep, scenario_index):
         capacity_cms = 700 / 35.31  # cfs to cms

--- a/sierra/models/stanislaus/_parameters/Donnells_Reservoir_Storage_Value.py
+++ b/sierra/models/stanislaus/_parameters/Donnells_Reservoir_Storage_Value.py
@@ -1,8 +1,8 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 from math import exp
 
 
-class Donnells_Reservoir_Storage_Value(WaterLPParameter):
+class Donnells_Reservoir_Storage_Value(BaseParameter):
 
     def _value(self, timestep, scenario_index):
         base_cost = -60

--- a/sierra/models/stanislaus/_parameters/Lake_Tulloch_Flood_Control_Requirement.py
+++ b/sierra/models/stanislaus/_parameters/Lake_Tulloch_Flood_Control_Requirement.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class Lake_Tulloch_Flood_Control_Requirement(WaterLPParameter):
+class Lake_Tulloch_Flood_Control_Requirement(BaseParameter):
     """"""
 
     def _value(self, timestep, scenario_index):

--- a/sierra/models/stanislaus/_parameters/Lake_Tulloch_Min_Volume.py
+++ b/sierra/models/stanislaus/_parameters/Lake_Tulloch_Min_Volume.py
@@ -1,7 +1,7 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class Lake_Tulloch_Min_Volume(WaterLPParameter):
+class Lake_Tulloch_Min_Volume(BaseParameter):
 
     def _value(self, timestep, scenario_index):
         flood_control_req = self.model.tables["Lake Tulloch Flood Control"]

--- a/sierra/models/stanislaus/_parameters/Lake_Tulloch_Storage_Demand.py
+++ b/sierra/models/stanislaus/_parameters/Lake_Tulloch_Storage_Demand.py
@@ -1,7 +1,7 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class Lake_Tulloch_Storage_Demand(WaterLPParameter):
+class Lake_Tulloch_Storage_Demand(BaseParameter):
 
     def _value(self, timestep, scenario_index):
         flood_control_req = self.model.tables["Lake Tulloch Flood Control"]

--- a/sierra/models/stanislaus/_parameters/Lake_Tulloch_Storage_Value.py
+++ b/sierra/models/stanislaus/_parameters/Lake_Tulloch_Storage_Value.py
@@ -1,7 +1,7 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class Lake_Tulloch_Storage_Value(WaterLPParameter):
+class Lake_Tulloch_Storage_Value(BaseParameter):
 
     def _value(self, timestep, scenario_index):
         if (4, 1) <= (self.datetime.month, self.datetime.day) <= (9, 15):

--- a/sierra/models/stanislaus/_parameters/New_Melones_Apr_Jul_Runoff.py
+++ b/sierra/models/stanislaus/_parameters/New_Melones_Apr_Jul_Runoff.py
@@ -1,8 +1,8 @@
 import numpy as np
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class New_Melones_Apr_Jul_Runoff(WaterLPParameter):
+class New_Melones_Apr_Jul_Runoff(BaseParameter):
     """"""
 
     def setup(self):

--- a/sierra/models/stanislaus/_parameters/New_Melones_Lake_Flood_Control_Requirement.py
+++ b/sierra/models/stanislaus/_parameters/New_Melones_Lake_Flood_Control_Requirement.py
@@ -1,11 +1,11 @@
 import numpy as np
 from datetime import datetime, timedelta
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class New_Melones_Lake_Flood_Control_Requirement(WaterLPParameter):
+class New_Melones_Lake_Flood_Control_Requirement(BaseParameter):
     """"""
 
     def setup(self):

--- a/sierra/models/stanislaus/_parameters/New_Melones_WYT.py
+++ b/sierra/models/stanislaus/_parameters/New_Melones_WYT.py
@@ -1,8 +1,8 @@
 import numpy as np
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class New_Melones_WYT(WaterLPParameter):
+class New_Melones_WYT(BaseParameter):
     """"""
 
     def setup(self):

--- a/sierra/models/stanislaus/_parameters/Oakdale_Irrigation_District_Demand.py
+++ b/sierra/models/stanislaus/_parameters/Oakdale_Irrigation_District_Demand.py
@@ -1,8 +1,8 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 from dateutil.relativedelta import relativedelta
 
 
-class Oakdale_Irrigation_District_Demand(WaterLPParameter):
+class Oakdale_Irrigation_District_Demand(BaseParameter):
 
     OID_bias_factor = 1.02
     

--- a/sierra/models/stanislaus/_parameters/PH_Cost.py
+++ b/sierra/models/stanislaus/_parameters/PH_Cost.py
@@ -1,8 +1,8 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 from calendar import isleap
 
 
-class PH_Cost(WaterLPParameter):
+class PH_Cost(BaseParameter):
     """"""
 
     # path = "s3_imports/energy_netDemand.csv"

--- a/sierra/models/stanislaus/_parameters/Pinecrest_Reservoir_Storage_Value.py
+++ b/sierra/models/stanislaus/_parameters/Pinecrest_Reservoir_Storage_Value.py
@@ -1,8 +1,8 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 from math import exp
 
 
-class Pinecrest_Reservoir_Storage_Value(WaterLPParameter):
+class Pinecrest_Reservoir_Storage_Value(BaseParameter):
 
     def _value(self, timestep, scenario_index):
         base_cost = -60

--- a/sierra/models/stanislaus/_parameters/Relief_Reservoir_Storage_Value.py
+++ b/sierra/models/stanislaus/_parameters/Relief_Reservoir_Storage_Value.py
@@ -1,8 +1,8 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 from math import exp
 
 
-class Relief_Reservoir_Storage_Value(WaterLPParameter):
+class Relief_Reservoir_Storage_Value(BaseParameter):
 
     def _value(self, timestep, scenario_index):
         base_cost = -60

--- a/sierra/models/stanislaus/_parameters/Sand_Bar_PH_Turbine_Capacity.py
+++ b/sierra/models/stanislaus/_parameters/Sand_Bar_PH_Turbine_Capacity.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class Sand_Bar_PH_Turbine_Capacity(WaterLPParameter):
+class Sand_Bar_PH_Turbine_Capacity(BaseParameter):
 
     def _value(self, timestep, scenario_index):
         capacity_cms = 600 / 35.31  # cfs to cms

--- a/sierra/models/stanislaus/_parameters/South_San_Joaquin_Irrigation_District_Demand.py
+++ b/sierra/models/stanislaus/_parameters/South_San_Joaquin_Irrigation_District_Demand.py
@@ -1,8 +1,8 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 from dateutil.relativedelta import relativedelta
 
 
-class South_San_Joaquin_Irrigation_District_Demand(WaterLPParameter):
+class South_San_Joaquin_Irrigation_District_Demand(BaseParameter):
     
     SSJID_bias_factor = 1.07
     

--- a/sierra/models/stanislaus/_parameters/Spring_Gap_PH_Turbine_Capacity.py
+++ b/sierra/models/stanislaus/_parameters/Spring_Gap_PH_Turbine_Capacity.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class Spring_Gap_PH_Turbine_Capacity(WaterLPParameter):
+class Spring_Gap_PH_Turbine_Capacity(BaseParameter):
 
     def _value(self, timestep, scenario_index):
         capacity_cms = 62 / 35.31  # cfs to cms

--- a/sierra/models/stanislaus/_parameters/Upper_Collierville_Tunnel_1_Capacity.py
+++ b/sierra/models/stanislaus/_parameters/Upper_Collierville_Tunnel_1_Capacity.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class Upper_Collierville_Tunnel_1_Capacity(WaterLPParameter):
+class Upper_Collierville_Tunnel_1_Capacity(BaseParameter):
 
     def _value(self, timestep, scenario_index):
         capacity_cms = 800 / 35.31  # cfs to cms

--- a/sierra/models/stanislaus/_parameters/Water_Supply_Release_bl_New_Spicer_Meadow_Reservoir.py
+++ b/sierra/models/stanislaus/_parameters/Water_Supply_Release_bl_New_Spicer_Meadow_Reservoir.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class Water_Supply_Release_bl_New_Spicer_Meadow_Reservoir(WaterLPParameter):
+class Water_Supply_Release_bl_New_Spicer_Meadow_Reservoir(BaseParameter):
     """"""
 
     def _value(self, timestep, scenario_index):

--- a/sierra/models/tuolumne/_parameters/Dion_R_Holm_PH_Demand.py
+++ b/sierra/models/tuolumne/_parameters/Dion_R_Holm_PH_Demand.py
@@ -1,12 +1,12 @@
 import pandas as pd
 import numpy as np
 import datetime as dt
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class Dion_R_Holm_PH_Demand(WaterLPParameter):
+class Dion_R_Holm_PH_Demand(BaseParameter):
     """"""
 
     max_release_cms = 27.47

--- a/sierra/models/tuolumne/_parameters/Districts_Entitlements.py
+++ b/sierra/models/tuolumne/_parameters/Districts_Entitlements.py
@@ -1,7 +1,7 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class Districts_Entitlements(WaterLPParameter):
+class Districts_Entitlements(BaseParameter):
 
     def _value(self, timestep, scenario_index):
 

--- a/sierra/models/tuolumne/_parameters/Don_Pedro_Lake_Flood_Control_Requirement.py
+++ b/sierra/models/tuolumne/_parameters/Don_Pedro_Lake_Flood_Control_Requirement.py
@@ -1,10 +1,10 @@
 from datetime import datetime
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class Don_Pedro_Lake_Flood_Control_Requirement(WaterLPParameter):
+class Don_Pedro_Lake_Flood_Control_Requirement(BaseParameter):
     """"""
 
     def _value(self, timestep, scenario_index):

--- a/sierra/models/tuolumne/_parameters/Eleanor_Cherry_Gravity_Requirement.py
+++ b/sierra/models/tuolumne/_parameters/Eleanor_Cherry_Gravity_Requirement.py
@@ -1,7 +1,7 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class Eleanor_Cherry_Gravity_Requirement(WaterLPParameter):
+class Eleanor_Cherry_Gravity_Requirement(BaseParameter):
 
     def _value(self, timestep, scenario_index):
 

--- a/sierra/models/tuolumne/_parameters/Eleanor_Cherry_Pumping_Requirement.py
+++ b/sierra/models/tuolumne/_parameters/Eleanor_Cherry_Pumping_Requirement.py
@@ -1,7 +1,7 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class Eleanor_Cherry_Pumping_Requirement(WaterLPParameter):
+class Eleanor_Cherry_Pumping_Requirement(BaseParameter):
 
     def _value(self, timestep, scenario_index):
 

--- a/sierra/models/tuolumne/_parameters/Kirkwood_PH_Demand.py
+++ b/sierra/models/tuolumne/_parameters/Kirkwood_PH_Demand.py
@@ -1,10 +1,10 @@
 import numpy as np
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 from datetime import datetime
 from sierra.utilities.converter import convert
 
 
-class Kirkwood_PH_Demand(WaterLPParameter):
+class Kirkwood_PH_Demand(BaseParameter):
     """"""
 
     prev_release_cms = None

--- a/sierra/models/tuolumne/_parameters/Lake_Eleanor_Forecasted_Inflow.py
+++ b/sierra/models/tuolumne/_parameters/Lake_Eleanor_Forecasted_Inflow.py
@@ -1,9 +1,9 @@
 import pandas as pd
 from datetime import timedelta
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class Lake_Eleanor_Forecasted_Inflow(WaterLPParameter):
+class Lake_Eleanor_Forecasted_Inflow(BaseParameter):
 
     def _value(self, timestep, scenario_index):
 

--- a/sierra/models/tuolumne/_parameters/Lower_Cherry_Aqueduct_1_Flow_Requirement.py
+++ b/sierra/models/tuolumne/_parameters/Lower_Cherry_Aqueduct_1_Flow_Requirement.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class Lower_Cherry_Aqueduct_1_Flow_Requirement(WaterLPParameter):
+class Lower_Cherry_Aqueduct_1_Flow_Requirement(BaseParameter):
     """"""
 
     def _value(self, timestep, scenario_index):

--- a/sierra/models/tuolumne/_parameters/Modesto_Irrigation_Districit_Demand.py
+++ b/sierra/models/tuolumne/_parameters/Modesto_Irrigation_Districit_Demand.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class Modesto_Irrigation_District_Demand(WaterLPParameter):
+class Modesto_Irrigation_District_Demand(BaseParameter):
     """"""
     WYT_names = ["Critical", "Dry", "Below", "Above", "Wet"]
 

--- a/sierra/models/tuolumne/_parameters/SFPUC_requirement_Demand.py
+++ b/sierra/models/tuolumne/_parameters/SFPUC_requirement_Demand.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class SFPUC_requirement_Demand(WaterLPParameter):
+class SFPUC_requirement_Demand(BaseParameter):
     """"""
 
     def _value(self, timestep, scenario_index):

--- a/sierra/models/tuolumne/_parameters/SFPUC_requirement_Demand_Reduction.py
+++ b/sierra/models/tuolumne/_parameters/SFPUC_requirement_Demand_Reduction.py
@@ -1,8 +1,8 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 import numpy as np
 
 
-class SFPUC_requirement_Demand_Reduction(WaterLPParameter):
+class SFPUC_requirement_Demand_Reduction(BaseParameter):
     """"""
 
     def setup(self):

--- a/sierra/models/tuolumne/_parameters/Turlock_Irrigation_Districit_Demand.py
+++ b/sierra/models/tuolumne/_parameters/Turlock_Irrigation_Districit_Demand.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class Turlock_Irrigation_District_Demand(WaterLPParameter):
+class Turlock_Irrigation_District_Demand(BaseParameter):
     """"""
 
     WYT_names = ["Critical", "Dry", "Below", "Above", "Wet"]

--- a/sierra/models/tuolumne/_parameters/Water_Bank.py
+++ b/sierra/models/tuolumne/_parameters/Water_Bank.py
@@ -1,8 +1,8 @@
 import numpy as np
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class Water_Bank(WaterLPParameter):
+class Water_Bank(BaseParameter):
     initial_storage = None
 
     def setup(self):

--- a/sierra/models/upper_san_joaquin/_parameters/Bass_Lake_Storage_Value.py
+++ b/sierra/models/upper_san_joaquin/_parameters/Bass_Lake_Storage_Value.py
@@ -1,7 +1,7 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class Bass_Lake_Storage_Value(WaterLPParameter):
+class Bass_Lake_Storage_Value(BaseParameter):
     """"""
 
     def _value(self, timestep, scenario_index):

--- a/sierra/models/upper_san_joaquin/_parameters/Big_Creek_System_IFRs_2000.py
+++ b/sierra/models/upper_san_joaquin/_parameters/Big_Creek_System_IFRs_2000.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class Big_Creek_System_IFRs_2000(WaterLPParameter):
+class Big_Creek_System_IFRs_2000(BaseParameter):
     """"""
 
     def _value(self, timestep, scenario_index):

--- a/sierra/models/upper_san_joaquin/_parameters/CVP_Madera_Canal_Demand.py
+++ b/sierra/models/upper_san_joaquin/_parameters/CVP_Madera_Canal_Demand.py
@@ -1,9 +1,9 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
 
-class CVP_Madera_Canal_Demand(WaterLPParameter):
+class CVP_Madera_Canal_Demand(BaseParameter):
     """"""
 
     def _value(self, timestep, scenario_index):

--- a/sierra/models/upper_san_joaquin/_parameters/Florence_Lake_Storage_Value.py
+++ b/sierra/models/upper_san_joaquin/_parameters/Florence_Lake_Storage_Value.py
@@ -1,7 +1,7 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class Florence_Lake_Storage_Value(WaterLPParameter):
+class Florence_Lake_Storage_Value(BaseParameter):
     """"""
 
     def _value(self, timestep, scenario_index):

--- a/sierra/models/upper_san_joaquin/_parameters/Friant_Kern_Canal_Demand_Demand.py
+++ b/sierra/models/upper_san_joaquin/_parameters/Friant_Kern_Canal_Demand_Demand.py
@@ -1,8 +1,8 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 from sierra.utilities.converter import convert
 
-class Friant_Kern_Canal_Demand_Demand(WaterLPParameter):
+class Friant_Kern_Canal_Demand_Demand(BaseParameter):
     """"""
     FKCD_bias_factor = 1.23
     

--- a/sierra/models/upper_san_joaquin/_parameters/Huntington_Lake_Cost.py
+++ b/sierra/models/upper_san_joaquin/_parameters/Huntington_Lake_Cost.py
@@ -1,8 +1,8 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
 cost = 0
-class Huntington_Lake_Cost(WaterLPParameter):
+class Huntington_Lake_Cost(BaseParameter):
     """"""
     def _value(self, timestep, scenario_index):
         # return 0.0

--- a/sierra/models/upper_san_joaquin/_parameters/Millerton_Lake_Flood_Release_Requirement.py
+++ b/sierra/models/upper_san_joaquin/_parameters/Millerton_Lake_Flood_Release_Requirement.py
@@ -1,11 +1,11 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 from datetime import datetime, timedelta
 import numpy as np
 from sierra.utilities.converter import convert
 import math
 
 
-class Millerton_Lake_Flood_Release_Requirement(WaterLPParameter):
+class Millerton_Lake_Flood_Release_Requirement(BaseParameter):
 
     should_drawdown = None
 

--- a/sierra/models/upper_san_joaquin/policies/USBR_Big_Creek_WYT.py
+++ b/sierra/models/upper_san_joaquin/policies/USBR_Big_Creek_WYT.py
@@ -1,7 +1,7 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class USBR_Big_Creek_WYT(WaterLPParameter):
+class USBR_Big_Creek_WYT(BaseParameter):
     """"""
 
     wyt = 1  # assume a normal year

--- a/sierra/parameters/PH_Cost.py
+++ b/sierra/parameters/PH_Cost.py
@@ -1,8 +1,8 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 from calendar import isleap
 
 
-class PH_Cost(WaterLPParameter):
+class PH_Cost(BaseParameter):
     """"""
 
     # path = "s3_imports/energy_netDemand.csv"

--- a/sierra/parameters/PH_Water_Demand.py
+++ b/sierra/parameters/PH_Water_Demand.py
@@ -1,11 +1,11 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 from dateutil.relativedelta import relativedelta
 from calendar import isleap
 import random
 import numpy as np
 
 
-class PH_Water_Demand(WaterLPParameter):
+class PH_Water_Demand(BaseParameter):
     """"""
 
     price_threshold = None

--- a/sierra/parameters/San_Joaquin_Valley_WYI.py
+++ b/sierra/parameters/San_Joaquin_Valley_WYI.py
@@ -1,7 +1,7 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class San_Joaquin_Valley_WYI(WaterLPParameter):
+class San_Joaquin_Valley_WYI(BaseParameter):
     """
     San Joaquin Valley Water Year Index = 0.6 * Current Apr-Jul Runoff Forecast (in maf)
    + 0.2 * Current Oct-Mar Runoff in (maf) + 0.2 * Previous Water Year's Index

--- a/sierra/parameters/San_Joaquin_Valley_WYT.py
+++ b/sierra/parameters/San_Joaquin_Valley_WYT.py
@@ -1,7 +1,7 @@
-from sierra.base_parameters import WaterLPParameter
+from sierra.base_parameters import BaseParameter
 
 
-class San_Joaquin_Valley_WYT(WaterLPParameter):
+class San_Joaquin_Valley_WYT(BaseParameter):
     """"""
 
     def _value(self, timestep, scenario_index):


### PR DESCRIPTION
This is a simple refactor, to rename the previous WaterLPParameter to BaseParameter, to be consistent with methods paper.

The previous WaterLPParameter was based on old code and concepts that are not really relevant anymore.