### PR TITLE
fix a couple of issues with flood control recorders

### DIFF
--- a/sierra/models/stanislaus/pywr_model.json
+++ b/sierra/models/stanislaus/pywr_model.json
@@ -3931,9 +3931,13 @@
             "type": "NumpyArrayParameterRecorder",
             "parameter": "New Melones Lake/Water Year Type"
         },
-        "New Melones Lake Flood Control/requirement": {
+        "New Melones Lake Flood Control/flow": {
             "type": "NumpyArrayNodeRecorder",
             "node": "New Melones Lake Flood Control"
+        },
+        "New Melones Lake Flood Control/requirement": {
+            "type": "NumpyArrayParameterRecorder",
+            "parameter": "New Melones Lake Flood Control/Requirement"
         },
         "New Spicer Meadow Reservoir/storage": {
             "type": "NumpyArrayStorageRecorder",

--- a/sierra/models/upper_san_joaquin/pywr_model.json
+++ b/sierra/models/upper_san_joaquin/pywr_model.json
@@ -7095,6 +7095,10 @@
             "type": "NumpyArrayParameterRecorder",
             "parameter": "Mammoth Pool Reservoir/Observed Storage"
         },
+        "Millerton Lake Flood Release/flow": {
+            "type": "NumpyArrayNodeRecorder",
+            "node": "Millerton Lake Flood Release"
+        },
         "Millerton Lake Flood Release/requirement": {
             "type": "NumpyArrayParameterRecorder",
             "parameter": "Millerton Lake Flood Release/Requirement"


### PR DESCRIPTION
It seems the flow and requirement for the flood control release nodes was not being consistently and correctly recorded. This PR fixes this.